### PR TITLE
Exit script if a single step fails

### DIFF
--- a/post_install.sh
+++ b/post_install.sh
@@ -3,6 +3,8 @@
 # based loosely on http://blog.self.li/post/74294988486/creating-a-post-installation-script-for-ubuntu
 # last updated for Ubuntu 16.04
 
+set -e
+
 # disable prompts for apt-get
 DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
This can prevent things like:

``` bash
export MY_DIR=`cd docs && pwd`
cd $MY_DIR
rm -rf .
```

Where if docs didn't exist, then you early instead of cd'ing into your home directory and removing everything.
